### PR TITLE
Use a common Packet format and preserve layer 2 information

### DIFF
--- a/netmap/src/Netmap.cc
+++ b/netmap/src/Netmap.cc
@@ -84,9 +84,8 @@ bool NetmapSource::ExtractNextPacket(Packet* pkt)
 		current_hdr.caplen = hdr.caplen;
 		current_hdr.len = hdr.len;
 
-		pkt->ts = current_hdr.ts.tv_sec + double(current_hdr.ts.tv_usec) / 1e6;
-		pkt->hdr = &current_hdr;
-		pkt->data = last_data = data;
+		last_data = data;
+		pkt->Init(props.link_type, &current_hdr.ts, current_hdr.caplen, current_hdr.len, data);
 
 		if ( current_hdr.len == 0 || current_hdr.caplen == 0 )
 			{


### PR DESCRIPTION
See pull request #30 in main bro repo for more info.

Refactor to make bro use a common Packet object.
Do a better job of parsing layer 2 and keeping track of layer 3 proto.
Add support for raw packet event, including Layer2 headers.

This adapts the Netmap plugin for the new Packet framework. I don't have any easy of testing it so it hasn't been tested. The diff however is very small and almost identical to the regular pcap interface.
