### PR TITLE
Capitalize Myricom_ROOT_DIR in configure.plugin

### DIFF
--- a/myricom/configure.plugin
+++ b/myricom/configure.plugin
@@ -11,7 +11,7 @@ plugin_option() {
 
     case "$1" in
         --with-myricom=*)
-            append_cache_entry Myricom_ROOT_DIR PATH $optarg
+            append_cache_entry MYRICOM_ROOT_DIR PATH $optarg
             return 0
             ;;
 


### PR DESCRIPTION
Before changing Myricom_ROOT_DIR to MYRICOM_ROOT_DIR configure fails with:
$ ./configure --with-myricom=/opt/snf --bro-dist=/home/src/bro-2.4-267
...
-- Could NOT find MYRICOM (missing:  MYRICOM_LIBRARY MYRICOM_INCLUDE_DIR)
-- Myricom prefix      : MYRICOM_ROOT_DIR-NOTFOUND
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.