### PR TITLE
BIT-1559 Bro-Plugins Send each log stream to different kafka topic

### DIFF
--- a/kafka/README
+++ b/kafka/README
@@ -13,7 +13,16 @@ Installation
 ------------
 
 Install librdkafka (https://github.com/edenhill/librdkafka), a native client
-library for Kafka.  Then compile this Bro plugin using the following commands.
+library for Kafka.  This plugin has been tested against the latest release of
+librdkafka, which at the time of this writing is v0.8.6.
+
+    # curl -L https://github.com/edenhill/librdkafka/archive/0.8.6.tar.gz | tar xvz
+    # cd librdkafka-0.8.6/
+    # ./configure
+    # make
+    # sudo make install
+
+Then compile this Bro plugin using the following commands.
 
     # ./configure --bro-dist=$BRO_SRC
     # make
@@ -28,21 +37,40 @@ Activation
 ----------
 
 The easiest way to enable Kafka output is to load the plugin's
-``logs-to-kafka.bro`` script.  If you are using BroControl, the following lines
-added to local.bro will activate it.
+``logs-to-kafka.bro`` script.  If you are using BroControl, any of the following
+examples added to local.bro will activate it.
+
+In this example, all HTTP, DNS, and Conn logs will be sent to a Kafka Broker
+running on the localhost.  By default, the log stream's path will define the
+topic name.  The ``Conn::LOG`` will be sent to the topic ``conn`` and the
+``HTTP::LOG`` will be sent to the topic named ``http``.
 
 .. console::
 
     @load Bro/Kafka/logs-to-kafka.bro
-    redef Kafka::logs_to_send = set(Conn::LOG, HTTP::LOG, DNS::LOG);
-    redef Kafka::topic_name = "bro";
+    redef Kafka::logs_to_send = set(Conn::LOG, HTTP::LOG);
     redef Kafka::kafka_conf = table(
         ["metadata.broker.list"] = "localhost:9092"
     );
 
-This example will send all HTTP, DNS, and Conn logs to a Kafka broker running on
-the localhost to a topic called ``bro``. Any configuration value accepted by
-librdkafka can be added to the ``kafka_conf`` configuration table.
+If all log streams need to be sent to the same topic, define the name of
+the topic in a variable called ``topic_name``.  In this example, both
+``Conn::LOG`` and ``HTTP::LOG`` will be sent to the topic named ``bro``.
+
+.. console::
+
+    @load Bro/Kafka/logs-to-kafka.bro
+    redef Kafka::logs_to_send = set(Conn::LOG, HTTP::LOG);
+    redef Kafka::kafka_conf = table(
+        ["metadata.broker.list"] = "localhost:9092"
+    );
+    redef Kafka::topic_name = "bro";
+
+It is also possible to send each log stream to a unique topic and also customize
+those topic names.   This can be done through the same mechanism in
+which the name of a log file for a stream is customized.  Here is an old
+example (look for the $path_func field)
+http://blog.bro.org/2012/02/filtering-logs-with-bro.html.
 
 Settings
 --------
@@ -62,7 +90,9 @@ table.
 
 ``topic_name``
 
-The name of the topic in Kafka where all Bro logs will be sent to.
+The name of the topic in Kafka that *all* Bro log streams will be sent to.  If
+each log stream needs to be sent to a unique topic, this value should be left
+undefined.
 
 .. console::
 

--- a/kafka/scripts/Bro/Kafka/logs-to-kafka.bro
+++ b/kafka/scripts/Bro/Kafka/logs-to-kafka.bro
@@ -19,7 +19,8 @@ event bro_init() &priority=-5
 		{
 			local filter: Log::Filter = [
 				$name = fmt("kafka-%s", stream_id),
-				$writer = Log::WRITER_KAFKAWRITER
+				$writer = Log::WRITER_KAFKAWRITER,
+				$config = table(["stream_id"] = fmt("%s", stream_id))
 			];
 
 			Log::add_filter(stream_id, filter);

--- a/kafka/scripts/init.bro
+++ b/kafka/scripts/init.bro
@@ -1,7 +1,7 @@
 module Kafka;
 
 export {
-  const topic_name: string = "bro" &redef;
+  const topic_name: string = "" &redef;
   const max_wait_on_shutdown: count = 3000 &redef;
   const tag_json: bool = F &redef;
   const kafka_conf: table[string] of string = table(

--- a/kafka/src/KafkaWriter.cc
+++ b/kafka/src/KafkaWriter.cc
@@ -9,11 +9,11 @@
 using namespace logging;
 using namespace writer;
 
-KafkaWriter::KafkaWriter(WriterFrontend* frontend): WriterBackend(frontend), formatter(NULL), producer(NULL), topic(NULL)
+KafkaWriter::KafkaWriter(WriterFrontend* frontend): WriterBackend(frontend), formatter(NULL), rd_producer(NULL)
 {
-    // TODO do we need this??
-    topic_name.assign((const char*)BifConst::Kafka::topic_name->Bytes(),
-        BifConst::Kafka::topic_name->Len());
+  topic_name.assign(
+    (const char*)BifConst::Kafka::topic_name->Bytes(),
+    BifConst::Kafka::topic_name->Len());
 }
 
 KafkaWriter::~KafkaWriter()
@@ -21,16 +21,21 @@ KafkaWriter::~KafkaWriter()
 
 bool KafkaWriter::DoInit(const WriterInfo& info, int num_fields, const threading::Field* const* fields)
 {
+    // if no global 'topic_name' is defined, use the log stream's 'path'
+    if(topic_name.empty()) {
+        topic_name = info.path;
+    }
+
     // initialize the formatter
     if(BifConst::Kafka::tag_json) {
-      formatter = new threading::formatter::TaggedJSON(info.path, this, threading::formatter::JSON::TS_EPOCH);
+        formatter = new threading::formatter::TaggedJSON(info.path, this, threading::formatter::JSON::TS_EPOCH);
     } else {
-      formatter = new threading::formatter::JSON(this, threading::formatter::JSON::TS_EPOCH);
+        formatter = new threading::formatter::JSON(this, threading::formatter::JSON::TS_EPOCH);
     }
 
     // kafka global configuration
     string err;
-    conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
+    rd_conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
 
     // apply the user-defined settings to kafka
     Val* val = BifConst::Kafka::kafka_conf->AsTableVal();
@@ -45,7 +50,7 @@ bool KafkaWriter::DoInit(const WriterInfo& info, int num_fields, const threading
         string val = v->Value()->AsString()->CheckString();
 
         // apply setting to kafka
-        if (RdKafka::Conf::CONF_OK != conf->set(key, val, err)) {
+        if (RdKafka::Conf::CONF_OK != rd_conf->set(key, val, err)) {
             reporter->Error("Failed to set '%s'='%s': %s", key.c_str(), val.c_str(), err.c_str());
             return false;
         }
@@ -56,16 +61,16 @@ bool KafkaWriter::DoInit(const WriterInfo& info, int num_fields, const threading
     }
 
     // create kafka producer
-    producer = RdKafka::Producer::create(conf, err);
-    if (!producer) {
+    rd_producer = RdKafka::Producer::create(rd_conf, err);
+    if (!rd_producer) {
         reporter->Error("Failed to create producer: %s", err.c_str());
         return false;
     }
 
     // create handle to topic
-    topic_conf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
-    topic = RdKafka::Topic::create(producer, topic_name, topic_conf, err);
-    if (!topic) {
+    rd_topic_conf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
+    rd_topic = RdKafka::Topic::create(rd_producer, topic_name, rd_topic_conf, err);
+    if (!rd_topic) {
         reporter->Error("Failed to create topic handle: %s", err.c_str());
         return false;
     }
@@ -86,19 +91,19 @@ bool KafkaWriter::DoFinish(double network_time)
     int max_wait = BifConst::Kafka::max_wait_on_shutdown;
 
     // wait a bit for queued messages to be delivered
-    while (producer->outq_len() > 0 && waited <= max_wait) {
-        producer->poll(poll_interval);
+    while (rd_producer->outq_len() > 0 && waited <= max_wait) {
+        rd_producer->poll(poll_interval);
         waited += poll_interval;
     }
 
     // successful only if all messages delivered
-    if (producer->outq_len() == 0) {
-        reporter->Error("Unable to deliver %0d message(s)", producer->outq_len());
+    if (rd_producer->outq_len() == 0) {
+        reporter->Error("Unable to deliver %0d message(s)", rd_producer->outq_len());
         success = true;
     }
 
-    delete topic;
-    delete producer;
+    delete rd_topic;
+    delete rd_producer;
     delete formatter;
 
     return success;
@@ -118,12 +123,12 @@ bool KafkaWriter::DoWrite(int num_fields, const threading::Field* const* fields,
 
     // send the formatted log entry to kafka
     const char* raw = (const char*)buff.Bytes();
-    RdKafka::ErrorCode resp = producer->produce(
-        topic, RdKafka::Topic::PARTITION_UA, RdKafka::Producer::RK_MSG_COPY,
+    RdKafka::ErrorCode resp = rd_producer->produce(
+        rd_topic, RdKafka::Topic::PARTITION_UA, RdKafka::Producer::RK_MSG_COPY,
         const_cast<char*>(raw), strlen(raw), NULL, NULL);
 
     if (RdKafka::ERR_NO_ERROR == resp) {
-        producer->poll(0);
+        rd_producer->poll(0);
     }
     else {
         string err = RdKafka::err2str(resp);
@@ -155,7 +160,7 @@ bool KafkaWriter::DoSetBuf(bool enabled)
  */
 bool KafkaWriter::DoFlush(double network_time)
 {
-    producer->poll(0);
+    rd_producer->poll(0);
     return true;
 }
 
@@ -179,6 +184,6 @@ bool KafkaWriter::DoRotate(const char* rotated_path, double open, double close, 
  */
 bool KafkaWriter::DoHeartbeat(double network_time, double current_time)
 {
-    producer->poll(0);
+    rd_producer->poll(0);
     return true;
 }

--- a/kafka/src/KafkaWriter.h
+++ b/kafka/src/KafkaWriter.h
@@ -36,12 +36,14 @@ protected:
     virtual bool DoHeartbeat(double network_time, double current_time);
 
 private:
+    static const string default_topic_key;
+    string stream_id;
     string topic_name;
     threading::formatter::Formatter *formatter;
-    RdKafka::Producer* producer;
-    RdKafka::Topic* topic;
-    RdKafka::Conf* conf;
-    RdKafka::Conf* topic_conf;
+    RdKafka::Producer* rd_producer;
+    RdKafka::Topic* rd_topic;
+    RdKafka::Conf* rd_conf;
+    RdKafka::Conf* rd_topic_conf;
 };
 
 }}


### PR DESCRIPTION
The current Kafka log writer sends all log streams (conn, http, dns, etc) to the same Kafka topic.  This change allows the user to configure a separate topic for each log stream.  

Details on configuring this functionality has been pulled from the README.

> The easiest way to enable Kafka output is to load the plugin's logs-to-kafka.bro script. If you are using BroControl, any of the following examples added to local.bro will activate it.
> 
> In this example, all HTTP, DNS, and Conn logs will be sent to a Kafka Broker running on the localhost. By default, the log stream's path will define the topic name. The Conn::LOG will be sent to the topic conn and the HTTP::LOG will be sent to the topic named http.
> 
> ```
> @load Bro/Kafka/logs-to-kafka.bro
> redef Kafka::logs_to_send = set(Conn::LOG, HTTP::LOG);
> redef Kafka::kafka_conf = table(
>     ["metadata.broker.list"] = "localhost:9092"
> );
> ```
> 
> If all log streams need to be sent to the same topic, define the name of the topic in a variable called topic_name. In this example, both Conn::LOG and HTTP::LOG will be sent to the topic named bro.
> 
> ```
> @load Bro/Kafka/logs-to-kafka.bro
> redef Kafka::logs_to_send = set(Conn::LOG, HTTP::LOG);
> redef Kafka::kafka_conf = table(
>     ["metadata.broker.list"] = "localhost:9092"
> );
> redef Kafka::topic_name = "bro";
> ```
> 
> It is also possible to send each log stream to a unique topic and also customize those topic names. This can be done through the same mechanism in which the name of a log file for a stream is customized. Here is an old example (look for the $path_func field) http://blog.bro.org/2012/02/filtering-logs-with-bro.html.