### PR TITLE
Adding headers that otherwise caused `make` to fail for the postgres plugin

### DIFF
--- a/postgresql/README
+++ b/postgresql/README
@@ -78,3 +78,4 @@ To read back this data, use a script like this:
     	terminate();
     	}
 
+You will also have to make changes to the way authentication is handled by PostgreSQL, Since the bro plugin attempts to connect to Postgres via the same user that runs Bro.

--- a/postgresql/src/PostgresReader.cc
+++ b/postgresql/src/PostgresReader.cc
@@ -1,5 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
+#include <algorithm>
 #include <fstream>
 #include <sstream>
 #include <sys/types.h>
@@ -221,7 +222,7 @@ bool PostgreSQL::DoUpdate()
 
 	for ( int i = 0; i < num_fields; ++i ) {
 		string fieldname = fields[i]->name;
-		replace( fieldname.begin(), fieldname.end(), '.', '$' ); // for the moment, expect the same fieldname replacement as we do in the writer.
+		std::replace( fieldname.begin(), fieldname.end(), '.', '$' ); // for the moment, expect the same fieldname replacement as we do in the writer.
 
 		int pos = PQfnumber(res, fieldname.c_str());
 		if ( pos == -1 )
@@ -283,8 +284,7 @@ bool PostgreSQL::DoUpdate()
 	}
 
 // currently we do not support streaming
-bool PostgreSQL::DoHeartbeat(double network_time, double current_time) 
+bool PostgreSQL::DoHeartbeat(double network_time, double current_time)
 	{
 	return true;
 	}
-

--- a/postgresql/src/PostgresReader.h
+++ b/postgresql/src/PostgresReader.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <vector>
+#include <thread>
 
 #include "input/ReaderFrontend.h"
 #include "threading/formatters/Ascii.h"

--- a/postgresql/src/PostgresWriter.cc
+++ b/postgresql/src/PostgresWriter.cc
@@ -1,5 +1,6 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
+#include <algorithm>
 #include <string>
 #include <errno.h>
 #include <vector>
@@ -101,7 +102,7 @@ void PostgreSQL::CreateInsert(int num_fields, const Field* const * fields)
 	for ( int i = 0; i < num_fields; ++i )
 		{
 		string fieldname = fields[i]->name;
-		replace( fieldname.begin(), fieldname.end(), '.', '$' ); // postgres does not like "." in row names.
+		std::replace( fieldname.begin(), fieldname.end(), '.', '$' ); // postgres does not like "." in row names.
 
 		if ( i != 0 )
 			{
@@ -181,7 +182,7 @@ bool PostgreSQL::DoInit(const WriterInfo& info, int num_fields,
 		create += ",\n";
 
 		string name = field->name;
-		replace( name.begin(), name.end(), '.', '$' ); // postgres does not like "." in row names.
+		std::replace( name.begin(), name.end(), '.', '$' ); // postgres does not like "." in row names.
 		create += name;
 
 		string type = GetTableType(field->type, field->subtype);

--- a/postgresql/src/PostgresWriter.h
+++ b/postgresql/src/PostgresWriter.h
@@ -5,6 +5,8 @@
 #ifndef LOGGING_WRITER_POSTGRES_H
 #define LOGGING_WRITER_POSTGRES_H
 
+#include <thread>
+
 #include "logging/WriterBackend.h"
 #include "threading/formatters/Ascii.h"
 #include "libpq-fe.h"


### PR DESCRIPTION
This occurred while installing Bro-beta-2.5 from source on a blank Ubuntu machine.

Tested by creating a test db and reading a PCAP into bro and checking that conn entries are added to the correct DB and table.